### PR TITLE
Add notice to visitors clearly indicating that this is a forked repo.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to the RMI OPGEEv4 Repository
+
+> TBD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,18 @@
 # Contributing to the RMI OPGEEv4 Repository
 
-> TBD
+> [!NOTE]
+> This is a WIP and subject to change.
+
+## Branches
+
+### `default`
+This exists only to display the updated README notifying users that this is a forked repo and directing them to the original.
+
+### `main`
+Primary production branch. Should be stable and will be used as a source for any PRs submitted to the original repo.
+
+### `develop`
+Development/feature source branch. Will be kept up to date with `main`, but all work should start from here.
+
+### `original`
+This exists mostly as a convenience branch to allow developers to quickly reference the current state of `master` in OPGEEv4.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+### \* \* \* \* \* \* \* \* \* \* \* \* \*
+# STOP!!!
+
+> [!CAUTION]
+> This is not the original OPGEEv4 repository. DO NOT FORK OR CLONE THIS REPO!
+> ## Please refer to the *[OPGEEv4 Repository](https://github.com/msmasnadi/OPGEEv4)*.
+<br/>
+
+For RMI personnel, please refer to [CONTRIBUTING.md](./CONTRIBUTING.md)
+### \* \* \* \* \* \* \* \* \* \* \* \* \*
+<br/>
+
 [![Build Status](https://travis-ci.com/Stanford-EAO/OPGEEv4.svg?token=qVku1FaPpCm5v3f1zYpw&branch=master)](https://travis-ci.com/Stanford-EAO/OPGEEv4)
 [![codecov](https://codecov.io/gh/Stanford-EAO/OPGEEv4/branch/master/graph/badge.svg?token=NVziMt7tdD)](https://codecov.io/gh/Stanford-EAO/OPGEEv4)
 [![Coverage Status](https://coveralls.io/repos/github/Stanford-EAO/OPGEEv4/badge.svg?branch=master&t=xSjoF0)](https://coveralls.io/github/Stanford-EAO/OPGEEv4?branch=master)


### PR DESCRIPTION
Pretty self explanatory, but we want to very loudly direct any visitors to the original OPGEEv4 repository.

I also tried to create a branch scheme to support development. The issue is that if we submit a PR to the original repo, we need to ensure that we don't capture inappropriate changes (like telling everyone this is a fork) or changes only applicable to RMI.

This will almost certainly need to be refined and may require clearer separation for RMI-specific features/fixes and more general updates intended for the upstream repo.