### PR TITLE
Refactor audit data handling and saving

### DIFF
--- a/opgee/audit.py
+++ b/opgee/audit.py
@@ -1,20 +1,16 @@
 """Provides functionality for auditing the source of field attribute values."""
 
-from dataclasses import dataclass
-from enum import Enum, Flag, auto
-from pathlib import Path
+from enum import Flag, auto
 from typing import Literal, TypeGuard, TypedDict
 
 from lxml import etree
-import pandas as pd
 from pint import Quantity
 from pydot import Dot
 
 from opgee.attributes import AttrDefs
-from opgee.config import getParam
 from opgee.core import A
 from opgee.field import Field
-from opgee.graph import create_process_diagram, write_process_diagram
+from opgee.graph import create_process_diagram
 from opgee.log import getLogger
 from opgee.model_file import ModelFile
 from opgee.smart_defaults import SmartDefault

--- a/opgee/etc/system.cfg
+++ b/opgee/etc/system.cfg
@@ -74,6 +74,10 @@ OPGEE.LogConsole = True
 OPGEE.LogDir = %(Home)s/tmp
 OPGEE.LogFile = %(OPGEE.LogDir)s/opgee.log
 
+# Set default output dir
+OPGEE.output_dir = %(OPGEE.ProjectDir)s/results
+
+
 # Format strings for log files and console messages. Note doubled
 # '%%' required here around logging parameters to avoid attempted
 # variable substitution within the config system.

--- a/opgee/etc/system.cfg
+++ b/opgee/etc/system.cfg
@@ -74,10 +74,6 @@ OPGEE.LogConsole = True
 OPGEE.LogDir = %(Home)s/tmp
 OPGEE.LogFile = %(OPGEE.LogDir)s/opgee.log
 
-# Set default output dir
-OPGEE.output_dir = %(OPGEE.ProjectDir)s/results
-
-
 # Format strings for log files and console messages. Note doubled
 # '%%' required here around logging parameters to avoid attempted
 # variable substitution within the config system.

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -80,23 +80,19 @@ def test_audit_field(audit_model_file: ModelFile, tmp_path):
     field = model.get_field("audit-field")
     field.run(analysis)
     audit_data = audit_field(field, audit_model_file, "Processes")
-    assert audit_data is None
-    png_path = results_dir / f"{field.name}_process_graph.png"
-    assert png_path.exists()
-    png_path.unlink()
+    assert audit_data["field"] is None
+    assert audit_data["proc_graph"] is not None
 
     audit_data = audit_field(field, audit_model_file, "Field")
-    assert not png_path.exists()
-    assert audit_data is not None
+    assert audit_data["proc_graph"] is None
+    assert audit_data["field"] is not None
 
     audit_data = audit_field(field, audit_model_file, "All")
-    assert audit_data is not None
-    assert png_path.exists()
-    png_path.unlink()
+    assert audit_data["field"] is not None
+    assert audit_data["proc_graph"] is not None
 
     audit_data = audit_field(field, audit_model_file)
     assert audit_data is None
-    assert not png_path.exists()
 
 
 def audit_setup_and_run(tmp_path: Path, opgee, audit_level: str | None = None):
@@ -120,7 +116,7 @@ def audit_setup_and_run(tmp_path: Path, opgee, audit_level: str | None = None):
     ]
 
     opgee.run(argList=cmd)
-    return results_dir / "field_audit.csv", results_dir / f"{field.name}_process_graph.png"
+    return results_dir / "field_audit.csv", results_dir / "process_graphs" / f"{field.name}_process_graph.png"
 
 def test_audit_save_results(tmp_path: Path, audit_model_file: ModelFile, opgee_main):
     audit_path, proc_graph_path = audit_setup_and_run(tmp_path, opgee_main, "Field")


### PR DESCRIPTION
Fixes #12 

Instead of writing the pngs directly from within the field audit. The PR adds a helper function in `graph.py` to create the final `Dot` object and uses that method to generate the process graph for the field which is then added to the `FieldResult`. Then, pngs are actually written in  `save_results` in `manager.py`.

This also tidies the architecture a bit in that the auditing features are no longer responsible for saving/storing data.

Tests are updated to reflect the changes.