### PR TITLE
Boundary streams and TransmissionCompressor

### DIFF
--- a/opgee/etc/opgee.xml
+++ b/opgee/etc/opgee.xml
@@ -577,6 +577,10 @@
 			<Contains>gas</Contains>
 		</Stream>
 
+		<Stream name="prod exported gas" src="ProductionBoundary" dst="TransmissionCompressor">
+			<Contains>exported gas</Contains>
+		</Stream>
+
 		<Stream src="GasPartition" dst="ProductionBoundary">
 			<Contains>exported gas</Contains>
 		</Stream>

--- a/opgee/process.py
+++ b/opgee/process.py
@@ -1032,7 +1032,7 @@ class Boundary(Process):
             if not is_chosen_boundary:
                 for in_stream in self.inputs:
                     if in_stream.is_uninitialized():
-                        break
+                        continue
                     contents = in_stream.contents
                     if len(contents) != 1:
                         raise ModelValidationError(f"Streams to and from boundaries must have only a "

--- a/opgee/processes/crude_oil_storage.py
+++ b/opgee/processes/crude_oil_storage.py
@@ -68,8 +68,8 @@ class CrudeOilStorage(Process):
 
     def cache_attributes(self):
         self.oil_sands_mine = self.field.oil_sands_mine
-        self.f_FG_CS_VRU = self.attr("f_FG_CS_VRU")
-        self.f_FG_CS_FL = self.attr("f_FG_CS_FL")
+        self.f_FG_CS_VRU = self.attr("f_FG_CS_VRU") # default 0.9
+        self.f_FG_CS_FL = self.attr("f_FG_CS_FL") # default 0.1
 
     def run(self, analysis):
         self.print_running_msg()

--- a/opgee/processes/transmission_compressor.py
+++ b/opgee/processes/transmission_compressor.py
@@ -63,7 +63,7 @@ class TransmissionCompressor(Process):
     def run(self, analysis):
         self.print_running_msg()
 
-        input = self.find_input_stream("gas")
+        input = self.find_input_streams(".*gas", regex=True, combine=True)
 
         if input.is_uninitialized():
             return

--- a/opgee/processes/transmission_compressor.py
+++ b/opgee/processes/transmission_compressor.py
@@ -26,7 +26,7 @@ class TransmissionCompressor(Process):
 
         # TODO: avoid process names in contents.
         self._required_inputs = [
-            "gas",
+            ".*gas",
         ]
 
         self._required_outputs = [


### PR DESCRIPTION
This PR addresses 2 items:
- Boundary instances exit their input stream loop if any one is "uninitialized" resulting in the loss of subsequent stream outputs
- the `TransmissionCompressor` only accepts a single `gas` input, but multiple gas streams with other names may exit the `ProductionBoundary`

Fixes:
- use `continue` in `Boundary` to iterate through all input streams and set their commensurate output
- use `".*gas"` regex in declaring `TransmissionCompressor` input streams
  - Note: this is due to the `ProductionBoundary` now passing both `export gas` and `gas`

Fixes #21 