### PR TITLE
Transmission Compressor Leak Rate

### DIFF
--- a/opgee/etc/attributes.xml
+++ b/opgee/etc/attributes.xml
@@ -673,6 +673,7 @@
       <AttrDef name="transmission_dist" type="float" unit="mile" desc="Gas transmission distance">680.0</AttrDef>
       <AttrDef name="transmission_freq" type="float" unit="mile" desc="Frequency of gas transmission compressors"> 200.0</AttrDef>
       <AttrDef name="transmission_inlet_press" type="float" unit="psia" desc="First compressor stage inlet pressure">1015.26</AttrDef>
+      <AttrDef name="transmission_loss_rate" type="float" unit="percent" desc="Percent transmission gas loss rate">3.0</AttrDef>
       <Options name="prime_mover_type" default="NG_engine">
         <Option>NG_engine</Option>
         <Option>Electric_motor</Option>

--- a/opgee/processes/transmission_compressor.py
+++ b/opgee/processes/transmission_compressor.py
@@ -58,7 +58,7 @@ class TransmissionCompressor(Process):
         self.gas_to_storage_frac = self.attr("gas_to_storage_frac")
         self.natural_gas_to_liquefaction_frac = self.field.natural_gas_to_liquefaction_frac
         self.transmission_sys_discharge = self.attr("transmission_sys_discharge")
-        self.loss_rate = self.venting_fugitive_rate()
+        self.loss_rate = self.attr("transmission_loss_rate")
 
     def run(self, analysis):
         self.print_running_msg()


### PR DESCRIPTION
Small change to add xml input for leak rate specific to the TransmissionCompressor and set a default of 0.03/3%.