### PR TITLE
Apply `--no-default-model` CLI flag to global config

### DIFF
--- a/opgee/built_ins/run_plugin.py
+++ b/opgee/built_ins/run_plugin.py
@@ -133,7 +133,7 @@ class RunCommand(SubcommandABC):
         parser.add_argument(
             "-n",
             "--no-default-model",
-            action="store_true",
+            action="store_const",
             help="""Don't load the built-in opgee.xml model definition.""",
         )
 
@@ -251,7 +251,7 @@ class RunCommand(SubcommandABC):
         start_with = args.start_with
         trial_nums = None
         trials = args.trials
-        use_default_model = not args.no_default_model
+        use_default_model = not args.no_default_model if args.no_default_model is not None else None
 
         # TBD: conceptual problem: XML model merging doesn't happen until after we look for
         #  analyses and fields in the model XML. Might want to do XML-level merging before
@@ -290,7 +290,8 @@ class RunCommand(SubcommandABC):
             raise CommandlineError(
                 "No model to run: the --model-file option was not used and --no-default-model was specified."
             )
-        setParam("OPGEE.UseDefaultModel", str(use_default_model))
+        if use_default_model is not None:
+            setParam("OPGEE.UseDefaultModel", str(use_default_model))
 
         # TBD: unclear if this is necessary
         setParam(

--- a/opgee/built_ins/run_plugin.py
+++ b/opgee/built_ins/run_plugin.py
@@ -290,6 +290,7 @@ class RunCommand(SubcommandABC):
             raise CommandlineError(
                 "No model to run: the --model-file option was not used and --no-default-model was specified."
             )
+        setParam("OPGEE.UseDefaultModel", str(use_default_model))
 
         # TBD: unclear if this is necessary
         setParam(

--- a/opgee/etc/system.cfg
+++ b/opgee/etc/system.cfg
@@ -48,6 +48,10 @@ OPGEE.ModelFile = etc/opgee.xml
 # are assumed to be within the opgee package.
 OPGEE.AttributesFile = etc/attributes.xml
 
+# Whether to load the default model file before merging additional input models
+# NOTE: overridden by `--no-default-model` cli option
+OPGEE.UseDefaultModel = True
+
 # Where to find user's attributes.xml files (optional)
 OPGEE.UserAttributesFile =
 
@@ -79,6 +83,11 @@ OPGEE.LogFile = %(OPGEE.LogDir)s/opgee.log
 # variable substitution within the config system.
 OPGEE.LogFileFormat    = %%(asctime)s %%(levelname)s %%(name)s:%%(lineno)d %%(message)s
 OPGEE.LogConsoleFormat = %%(levelname)s %%(name)s: %%(message)s
+
+# AuditLevel: Controls the level of attribute auditing.
+# Options: None (default, no audit), Field (audit field-level attributes), Processes (show process graph only), All
+# Note: Processes auditing (as well as "All") has a bug currently
+OPGEE.AuditLevel = None
 
 # Where to create temporary files
 OPGEE.TempDir = /tmp
@@ -147,7 +156,3 @@ SLURM.Interface =
 # Which shell to use for the sbatch script
 SLURM.Shell = /usr/bin/bash
 
-# AuditLevel: Controls the level of attribute auditing.
-# Options: None (default, no audit), Field (audit field-level attributes), Processes (show process graph only), All
-# Note: Processes auditing (as well as "All") has a bug currently
-OPGEE.AuditLevel = None

--- a/opgee/manager.py
+++ b/opgee/manager.py
@@ -387,10 +387,12 @@ def run_serial(model_xml_file, analysis_name, field_names, result_type=DETAILED_
 
     results = []
 
+    use_default_model = getParam("OPGEE.UseDefaultModel") or "False"
+
     # even though we pass 10 field names by default, each is passed singularly to `_run_field`
     for field_name, xml_string in extract_model(model_xml_file, analysis_name,
                                                 field_names):
-        result = _run_field(analysis_name, field_name, xml_string, result_type)
+        result = _run_field(analysis_name, field_name, xml_string, result_type, use_default_model == str(True))
         if result.error:
             _logger.error(f"Failed: {result}")
 


### PR DESCRIPTION
Fixes #26
Add `UseDefaultModel` to `system.cfg`
CLI flag will override .cfg settings if included.